### PR TITLE
Various fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lib/coq-ctproxy"]
 	path = lib/coq-ctproxy
-	url = git@github.com:Xiving/coq-ctproxy.git
+	url = https://github.com/Xiving/coq-ctproxy
 [submodule "lib/QuickChick"]
 	path = lib/QuickChick
-	url = git@github.com:Xiving/QuickChick.git
+	url = https://github.com/Xiving/QuickChick
 	branch = dec-derivining-mutind-bugfix

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 	+make -f Makefile.coq $@
 
 all: Makefile.coq
+	mkdir -p hs-src/PlutusIR/Certifier
 	+make -C lib/QuickChick
 	+make -f Makefile.coq all
 	sed -i 's/module Extracted/module PlutusIR.Certifier.Extracted/' hs-src/PlutusIR/Certifier/Extracted.hs

--- a/Setup.hs
+++ b/Setup.hs
@@ -20,5 +20,3 @@ userhooks = simpleUserHooks {
 runMake :: IO ()
 runMake = procs "make" [] empty
 
--- runAgda :: IO ()
--- runAgda = procs "agda" ["--compile", "--ghc-dont-call-ghc", "--local-interfaces", "src/Main.lagda"] empty

--- a/_CoqProject
+++ b/_CoqProject
@@ -1,5 +1,6 @@
 -R lib/coq-ctproxy/src CTProxy
 -R lib/QuickChick/src QuickChick
+-I lib/QuickChick/plugin 
 
 -Q src PlutusCert
 

--- a/plutus-cert.cabal
+++ b/plutus-cert.cabal
@@ -1,4 +1,4 @@
-cabal-version:      3.0
+cabal-version:      3.6
 name:               plutus-cert
 version:            0.1.0.0
 
@@ -19,9 +19,22 @@ maintainer:         j.o.g.krijnen@uu.nl
 -- A copyright notice.
 -- copyright:
 -- category:
-extra-source-files: CHANGELOG.md
-                    src/**/*.v
+extra-source-files: src/**/*.v
                     _CoqProject
+                    Makefile
+                    lib/QuickChick/_CoqProject
+                    lib/QuickChick/Makefile
+                    lib/QuickChick/Makefile.coq.local
+                    lib/coq-ctproxy/_CoqProject
+                    lib/coq-ctproxy/Makefile
+                    lib/**/*.v
+                    lib/**/*.ml
+                    lib/**/*.mlpack
+                    lib/**/*.mli
+                    lib/**/*.mll
+                    lib/**/*.mly
+                    lib/**/*.mlg
+                    lib/**/*.pl
 
 -- This makes cabal rebuild if any of these files change, which allow the
 -- custom setup to fire and rebuild the Haskell sources


### PR DESCRIPTION
- Change the submodule specification to use https to make nix happier
- Make sure `hs-src` and subdirs exist before building, otherwise it fails. Existing setup isn't sufficient to make it through `cabal sdist`
- Include all stuff needed to build libraries in `extra-source-files` so as to get through `cabal sdist`.