### PR TITLE
Subsitutions sometimes did not go under Forall binder

### DIFF
--- a/src/PlutusIR/Semantics/Static/TypeSubstitution.v
+++ b/src/PlutusIR/Semantics/Static/TypeSubstitution.v
@@ -118,7 +118,7 @@ Equations? substituteTCA (X : string) (U T : ty) : ty by wf (size T) :=
               let T' := rename Y Y' T in
               Ty_Forall Y' K (substituteTCA X U T')
             else
-              Ty_Forall Y K T ;
+              Ty_Forall Y K (substituteTCA X U T) ;
   substituteTCA X U (Ty_Builtin u) =>
       Ty_Builtin u ;
   substituteTCA X U (Ty_Lam Y K T) =>


### PR DESCRIPTION
In capture-avoiding type substitutions, we do a check to see if that which we substitute may cause capture. In the case that it did cause capture, we freshened the binder, and recursively substituted the body.

However, in the case where no capture would happen, we forgot to substitute the body recursively.